### PR TITLE
Listen for telegram:invoke event to allow using Telegram specific functionality

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -18,12 +18,8 @@ class Telegram extends Adapter
         ###*
         # Listen for Telegram API invokes from other scripts
         ###
-        @robot.on "telegram:invoke", ({method, opts})->
-            self.api.invoke method, opts, (err, message) =>
-                if (err)
-                    self.emit 'error', err
-                else
-                    self.robot.logger.info "Invoked event: " + method
+        @robot.on "telegram:invoke", (method, opts, cb) ->
+            self.api.invoke method, opts, cb
 
         # Get the bot information
         @api.invoke 'getMe', {}, (err, result) ->

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -15,6 +15,16 @@ class Telegram extends Adapter
 
         @robot.logger.info "Telegram Adapter Bot " + @token + " Loaded..."
 
+        ###*
+        # Listen for Telegram API invokes from other scripts
+        ###
+        @robot.on "telegram:invoke", ({method, opts})->
+            self.api.invoke method, opts, (err, message) =>
+                if (err)
+                    self.emit 'error', err
+                else
+                    self.robot.logger.info "Invoked event: " + method
+
         # Get the bot information
         @api.invoke 'getMe', {}, (err, result) ->
             if (err)


### PR DESCRIPTION
This is useful for doing stuff like image/audio uploads, and sending chat actions (e.g. recording audio).