### PR TITLE
Split messages into multiple parts to support the 4096 character limit Telegram imposes.

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -81,10 +81,13 @@ class Telegram extends Adapter
         limit = 4096
         parts = (Math.ceil bytes / limit) - 1
 
+        @robot.logger.debug "Message bytes: " + bytes
+        @robot.logger.debug "Message parts: " + parts
+
         for part in [0..parts]
             offset = part * limit
             messagePart = message.substr offset, offset + limit
-            @robot.logger.info "Sending message bytes: " + Buffer.byteLength(messagePart)
+            @robot.logger.debug "Sending message part " + part + " bytes: " + Buffer.byteLength(messagePart)
             opts.text = messagePart
 
             @api.invoke 'sendMessage', opts, cb

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -85,7 +85,7 @@ class Telegram extends Adapter
         parts = (Math.ceil length / limit) - 1
 
         @robot.logger.debug "Message length: " + length
-        @robot.logger.debug "Message parts: " + parts
+        @robot.logger.debug "Message parts: " + (parts + 1)
 
         for part in [0..parts]
             offset = part * limit

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -84,6 +84,7 @@ class Telegram extends Adapter
         for part in [0..parts]
             offset = part * limit
             messagePart = message.substr offset, offset + limit
+            @robot.logger.info "Sending message bytes: " + Buffer.byteLength(messagePart)
             opts.text = messagePart
 
             @api.invoke 'sendMessage', opts, cb
@@ -98,7 +99,7 @@ class Telegram extends Adapter
             if (err)
                 self.emit 'error', err
             else
-                self.robot.logger.info "Sending message (" + part + ") to room: " + envelope.room
+                self.robot.logger.info "Sending message to room: " + envelope.room
 
     ###*
     # The only difference between send() and reply() is that we add the "reply_to_message_id" parameter when

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -77,17 +77,20 @@ class Telegram extends Adapter
     apiSend: (opts, cb) ->
         @self = @
         message = opts.text
-        bytes = Buffer.byteLength message, 'utf8'
-        limit = 4096
-        parts = (Math.ceil bytes / limit) - 1
 
-        @robot.logger.debug "Message bytes: " + bytes
+        # We rely on lenght since it does not seem that Telegram cares too much about unicode
+        # using more bytes than a normal string.
+        length = message.length
+        limit = 4096
+        parts = (Math.ceil length / limit) - 1
+
+        @robot.logger.debug "Message length: " + length
         @robot.logger.debug "Message parts: " + parts
 
         for part in [0..parts]
             offset = part * limit
             messagePart = message.substr offset, offset + limit
-            @robot.logger.debug "Sending message part " + part + " bytes: " + Buffer.byteLength(messagePart)
+            @robot.logger.debug "Sending message part " + part + " length: " + messagePart.length
             opts.text = messagePart
 
             @api.invoke 'sendMessage', opts, cb

--- a/test/hubot.stub.js
+++ b/test/hubot.stub.js
@@ -11,6 +11,7 @@ module.exports = {
     logger: {
         info: void_func,
         warning: void_func,
-        error: void_func
+        error: void_func,
+        debug: void_func
     }
 }

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -65,9 +65,10 @@ describe('Telegram', function() {
 
             // Mock the API object
             telegram.api = {
-                invoke: function (method, opts) {
+                invoke: function (method, opts, cb) {
                     assert.equal(opts.text.length, 4096);
                     called++;
+                    cb.apply(this, [null, {}]);
                 }
             };
 
@@ -84,10 +85,11 @@ describe('Telegram', function() {
 
             // Mock the API object
             telegram.api = {
-                invoke: function (method, opts) {
+                invoke: function (method, opts, cb) {
                     var offset = called * 4096;
                     assert.equal(opts.text.length, message.substr(offset, offset + 4096).length);
                     called++;
+                    cb.apply(this, [null, {}]);
                 }
             };
 

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -87,7 +87,37 @@ describe('Telegram', function() {
             telegram.api = {
                 invoke: function (method, opts, cb) {
                     var offset = called * 4096;
-                    assert.equal(opts.text.length, message.substr(offset, offset + 4096).length);
+                    assert.equal(opts.text.length, message.substring(offset, offset + 4096).length);
+                    called++;
+                    cb.apply(this, [null, {}]);
+                }
+            };
+
+            telegram.send({ room: 1 }, message);
+            assert.equal(called, 2);
+        });
+
+        it('should not split messages on new line characters', function () {
+
+            var called = 0;
+
+            var message = "";
+            for (var i = 0; i < 1000; i++) message += 'a';
+            message += '\n';
+            for (var i = 0; i < 1000; i++) message += 'b';
+            message += '\n';
+            for (var i = 0; i < 1000; i++) message += 'c';
+            message += '\n';
+            for (var i = 0; i < 1000; i++) message += 'd';
+            message += '\n';
+            for (var i = 0; i < 1000; i++) message += 'e';
+            message += '\n';
+
+            // Mock the API object
+            telegram.api = {
+                invoke: function (method, opts, cb) {
+                    var offset = called * 4096;
+                    assert.equal(opts.text.length, message.substring(offset, offset + 4096).length);
                     called++;
                     cb.apply(this, [null, {}]);
                 }

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -56,7 +56,7 @@ describe('Telegram', function() {
 
     describe("#send()", function () {
 
-        it('should not split messages below or equal to 4096 bytes', function () {
+        it('should not split messages below or equal to 4096 characters', function () {
 
             var called = 0;
 
@@ -66,7 +66,7 @@ describe('Telegram', function() {
             // Mock the API object
             telegram.api = {
                 invoke: function (method, opts) {
-                    assert.equal(Buffer.byteLength(opts.text, 'utf8'), 4096);
+                    assert.equal(opts.text.length, 4096);
                     called++;
                 }
             };
@@ -75,7 +75,7 @@ describe('Telegram', function() {
             assert.equal(called, 1);
         });
 
-        it('should split messages when they are above 4096 bytes', function () {
+        it('should split messages when they are above 4096 characters', function () {
 
             var called = 0;
 
@@ -86,34 +86,13 @@ describe('Telegram', function() {
             telegram.api = {
                 invoke: function (method, opts) {
                     var offset = called * 4096;
-                    assert.equal(Buffer.byteLength(opts.text, 'utf8'), Buffer.byteLength(message.substr(offset, offset + 4096)));
+                    assert.equal(opts.text.length, message.substr(offset, offset + 4096).length);
                     called++;
                 }
             };
 
             telegram.send({ room: 1 }, message);
             assert.equal(called, 2);
-        });
-
-        it('should split unicode messages when they are above 4096 bytes', function () {
-
-            var called = 0;
-            var chars = 3000;
-
-            var message = "";
-            for (var i = 0; i < chars; i++) message += '╚';
-
-            // Mock the API object
-            telegram.api = {
-                invoke: function (method, opts) {
-                    var offset = called * 4096;
-                    assert.equal(Buffer.byteLength(opts.text, 'utf8'), Buffer.byteLength(message.substr(offset, offset + 4096)));
-                    called++;
-                }
-            };
-
-            telegram.send({ room: 1 }, message);
-            assert.equal(called, Math.ceil((chars * 4) / 4096));
         });
 
     });


### PR DESCRIPTION
Telegram has a limit of 4096 UTF8 characters, some scripts produce messages that have more characters. These messages will be split into multiple parts and be delivered sequentially to preserve the correct order.