### PR TITLE
Fix slash commands not working in group chats with robot.respond

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -40,14 +40,16 @@ class Telegram extends Adapter
     # @return string
     ###
     cleanMessageText: (text, chat_id) ->
-        # If we are running in privacy mode, strip out the stuff we don't need.
-        text = text.replace(/^\//g, '').trim()
-
         # If it is a private chat, automatically prepend the bot name if it does not exist already.
         if (chat_id > 0)
+            # Strip out the stuff we don't need.
+            text = text.replace(/^\//g, '').trim()
+
             text = text.replace(new RegExp('^@?' + @robot.name.toLowerCase(), 'gi'), '');
             text = text.replace(new RegExp('^@?' + @robot.alias.toLowerCase(), 'gi'), '') if @robot.alias
             text = @robot.name + ' ' + text.trim()
+        else
+            text = text.trim()
 
         return text
 

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -6,15 +6,15 @@ describe('Telegram', function() {
 
     describe('#cleanMessageText()', function () {
 
-        it('all chat: should remove any leading / characters from commands', function () {
+        it('private chat: should remove any leading / characters from commands', function () {
 
             var input = '/ship it';
-            var text = telegram.cleanMessageText(input, 0);
-            assert.equal('ship it', text);
+            var text = telegram.cleanMessageText(input, 1);
+            assert.equal(/\/ship it/.test(text), false);
 
             var input = '/ship it'
-            var text = telegram.cleanMessageText(input, 0);
-            assert.notEqual(text.substr(0, 1), '/');
+            var text = telegram.cleanMessageText(input, 1);
+            assert.notEqual(text.split(' ')[1].substr(0, 1), '/');
         });
 
         // eg. ship it => BotName ship it


### PR DESCRIPTION
As per [the hubot documentation](https://github.com/github/hubot/blob/master/docs/scripting.md#hearing-and-responding) callbacks registered with robot.respond are only triggered when the command name is preceded by the robot name or alias, so setting robot.alias to '/' makes robot.respond react to slash commands.
This doesn't work in group chats because the leading slash is removed by the adapter before the message is forwarded to the robot.