### PR TITLE
Allow telegram specific parameters to be passed along with the envelope object

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ module.exports = function (robot) {
 
 **Note:** An example script of how to use this is located in the `example/` folder
 
+If you want to supplement your message delivery with extra features such as **markdown** syntax or **keyboard** replies, you can specify these settings on the `res.envelope` variable in your plugin.
+
+``` nodejs
+
+robot.respond(/(.*)/i, function (res) {
+    res.envelope.telegram = { reply_markup: { keyboard: [["test"]] }}
+
+    res.reply("Select the option from the keyboard specified.");
+};
+
+```
+
+**Note:** Markdown will automatically be parsed if the supported markdown characters are included. You can override this by specifying the `parse_markdown` value in the `envelope.telegram` key.
+
 ## Contributors
 
 * Luke Simone - [https://github.com/lukefx](https://github.com/lukefx)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ robot.respond(/(.*)/i, function (res) {
 
 ```
 
-**Note:** Markdown will automatically be parsed if the supported markdown characters are included. You can override this by specifying the `parse_markdown` value in the `envelope.telegram` key.
+**Note:** Markdown will automatically be parsed if the supported markdown characters are included. You can override this by specifying the `parse_mode` value in the `envelope.telegram` key.
 
 ## Contributors
 

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -68,7 +68,7 @@ class Telegram extends Adapter
         autoMarkdown = /\*.+\*/.test(text) or /_.+_/.test(text) or /\[.+\]\(.+\)/.test(text) or /`.+`/.test(text)
 
         if autoMarkdown
-            message.parse_markdown = 'Markdown'
+            message.parse_mode = 'Markdown'
 
         if extra?
             for key, value of extra
@@ -162,7 +162,7 @@ class Telegram extends Adapter
             if (err)
                 self.emit 'error', err
             else
-                self.robot.logger.info "Reply message to room/message: " + envelope.room + "/" + envelope.id
+                self.robot.logger.info "Reply message to room/message: " + envelope.room + "/" + envelope.message.id
 
     ###*
     # "Private" method to handle a new update received via a webhook

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -54,6 +54,29 @@ class Telegram extends Adapter
         return text
 
     ###*
+    # Add extra options to the message packet before deliver. The extra options
+    # will be pulled from the message envelope
+    #
+    # @param object message
+    # @param object extra
+    #
+    # @return object
+    ###
+    applyExtraOptions: (message, extra) ->
+
+        text = message.text
+        autoMarkdown = /\*.+\*/.test(text) or /_.+_/.test(text) or /\[.+\]\(.+\)/.test(text) or /`.+`/.test(text)
+
+        if autoMarkdown
+            message.parse_markdown = 'Markdown'
+
+        if extra?
+            for key, value of extra
+                message[key] = value
+
+        return message
+
+    ###*
     # Get the last offset + 1, this will allow
     # the Telegram API to only return new relevant messages
     #
@@ -118,15 +141,7 @@ class Telegram extends Adapter
     send: (envelope, strings...) ->
         self = @
         text = strings.join()
-        data = { chat_id: envelope.room, text: text }
-
-        markdown = /\*.+\*/.test(text) or
-                    /_.+_/.test(text) or
-                    /\[.+\]\(.+\)/.test(text) or
-                    /`.+`/.test(text)
-
-        if markdown
-          data.parse_mode = 'Markdown'
+        data = @applyExtraOptions({ chat_id: envelope.room, text: text }, envelope.telegram);
 
         @apiSend data, (err, message) =>
             if (err)
@@ -141,15 +156,7 @@ class Telegram extends Adapter
     reply: (envelope, strings...) ->
         self = @
         text = strings.join()
-        data = { chat_id: envelope.room, text: text, reply_to_message_id: envelope.message.id }
-
-        markdown = /\*.+\*/.test(text) or
-                   /_.+_/.test(text) or
-                   /\[.+\]\(.+\)/.test(text) or
-                   /`.+`/.test(text)
-
-        if markdown
-          data.parse_mode = 'Markdown'
+        data = @applyExtraOptions({ chat_id: envelope.room, text: text, reply_to_message_id: envelope.message.id }, envelope.telegram);
 
         @apiSend data, (err, message) =>
             if (err)

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -60,23 +60,23 @@ describe('Telegram', function() {
 
             var message = { text: "normal" }
             message = telegram.applyExtraOptions(message);
-            assert(typeof message.parse_markdown === 'undefined');
+            assert(typeof message.parse_mode === 'undefined');
 
             message = { text: "markdown *message*" }
             message = telegram.applyExtraOptions(message);
-            assert.equal(message.parse_markdown, "Markdown");
+            assert.equal(message.parse_mode, "Markdown");
 
             message = { text: "markdown _message_" }
             message = telegram.applyExtraOptions(message);
-            assert.equal(message.parse_markdown, "Markdown");
+            assert.equal(message.parse_mode, "Markdown");
 
             message = { text: "markdown `message`" }
             message = telegram.applyExtraOptions(message);
-            assert.equal(message.parse_markdown, "Markdown");
+            assert.equal(message.parse_mode, "Markdown");
 
             message = { text: "markdown [message](http://link.com)" }
             message = telegram.applyExtraOptions(message);
-            assert.equal(message.parse_markdown, "Markdown");
+            assert.equal(message.parse_mode, "Markdown");
 
         });
 

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -54,6 +54,55 @@ describe('Telegram', function() {
         });
     });
 
+    describe("#applyExtraOptions()", function () {
+
+        it("should automatically add the markdown option if the text contains markdown characters", function () {
+
+            var message = { text: "normal" }
+            message = telegram.applyExtraOptions(message);
+            assert(typeof message.parse_markdown === 'undefined');
+
+            message = { text: "markdown *message*" }
+            message = telegram.applyExtraOptions(message);
+            assert.equal(message.parse_markdown, "Markdown");
+
+            message = { text: "markdown _message_" }
+            message = telegram.applyExtraOptions(message);
+            assert.equal(message.parse_markdown, "Markdown");
+
+            message = { text: "markdown `message`" }
+            message = telegram.applyExtraOptions(message);
+            assert.equal(message.parse_markdown, "Markdown");
+
+            message = { text: "markdown [message](http://link.com)" }
+            message = telegram.applyExtraOptions(message);
+            assert.equal(message.parse_markdown, "Markdown");
+
+        });
+
+        it("should apply any extra options passed the message envelope", function () {
+
+            var message = { text: "test" }
+            var extra = { extra: true, nested: { extra: true } };
+            message = telegram.applyExtraOptions(message, extra);
+
+            assert.equal(extra.extra, message.extra);
+            assert.equal(extra.nested.extra, message.nested.extra);
+
+            // Mock the API object
+            telegram.api = {
+                invoke: function (method, opts, cb) {
+                    assert.equal(extra.extra, opts.extra);
+                    assert.equal(extra.nested.extra, opts.nested.extra);
+                    cb.apply(this, [null, {}]);
+                }
+            };
+
+            telegram.send({ telegram: extra }, "text");
+        });
+
+    });
+
     describe("#createUser()", function () {
 
         it("should use the new user object if the first_name or last_name changed", function () {


### PR DESCRIPTION
Allow users to specify extra message parameters on the `envelope` object. These objects will merge with the message object before sending.

Use cases include:
- markdown
- reply_markup
- html preview