### PR TITLE
Change Webhook endpoint to a secret one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The token that the [BotFather](https://core.telegram.org/bots#botfather) gives y
 
 **TELEGRAM_WEBHOOK** (optional)
 
-You can specify a [webhook](https://core.telegram.org/bots/api#setwebhook) URL which the adapter will register with Telegram. This URL will receive updates from Telegram. The adapter automatically registers an endpoint with Hubot at http://your-hobot-host/hubot/telegram/receive.
+You can specify a [webhook](https://core.telegram.org/bots/api#setwebhook) URL. The adapter will register TELEGRAM_WEBHOOK/TELEGRAM_TOKEN with Telegram and listen there.
 
 **TELEGRAM_INTERVAL** (optional)
 

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -217,11 +217,14 @@ class Telegram extends Adapter
 
         if @webhook
 
-            @api.invoke 'setWebHook', { url: @webhook }, (err, result) ->
+            endpoint = @webhook + '/' + @token
+            @robot.logger.debug 'Listening on ' + endpoint
+
+            @api.invoke 'setWebHook', { url: endpoint }, (err, result) ->
                 if (err)
                     self.emit 'error', err
 
-            @robot.router.post "/hubot/telegram/receive", (req, res) =>
+            @robot.router.post "/" + @token, (req, res) =>
                 if req.body.message
                     self.handleUpdate req.body
 

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -232,7 +232,7 @@ class Telegram extends Adapter
 
         else
 	    # Clear Webhook
-            @api.invoke 'setWebHook', { url: null }, (err, result) ->
+            @api.invoke 'setWebHook', { url: '' }, (err, result) ->
                 if (err)
                     self.emit 'error', err
 

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -231,6 +231,11 @@ class Telegram extends Adapter
                 res.send 'OK'
 
         else
+	    # Clear Webhook
+            @api.invoke 'setWebHook', { url: null }, (err, result) ->
+                if (err)
+                    self.emit 'error', err
+
             setInterval ->
 
                 self.api.invoke 'getUpdates', { offset: self.getLastOffset(), limit: 10 }, (err, result) ->


### PR DESCRIPTION
Make the robot listen on TELEGRAM_WEBHOOK/TELEGRAM_TOKEN (e.g. https://example.com/123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11) for security reasons.

Fixes #30 