### PR TITLE
Move the offset update into the getUpdates method. #43

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -244,10 +244,9 @@ class Telegram extends Adapter
                     if (err)
                         self.emit 'error', err
                     else
-                        # Increment the current offset
-                        @offset = msg.update_id
-
                         for msg in result
+                            # Increment the current offset
+                            @offset = msg.update_id
                             self.handleUpdate msg
 
             , @interval

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -246,7 +246,7 @@ class Telegram extends Adapter
                     else
                         for msg in result
                             # Increment the current offset
-                            @offset = msg.update_id
+                            self.offset = msg.update_id
 
                         for msg in result
                             self.handleUpdate msg

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -247,6 +247,8 @@ class Telegram extends Adapter
                         for msg in result
                             # Increment the current offset
                             @offset = msg.update_id
+
+                        for msg in result
                             self.handleUpdate msg
 
             , @interval

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -206,9 +206,6 @@ class Telegram extends Adapter
             message.user = @createUser message.from, message.chat
             @receive new CatchAllMessage message
 
-        # Increment the current offset
-        @offset = update.update_id
-
     run: ->
         self = @
 
@@ -247,6 +244,9 @@ class Telegram extends Adapter
                     if (err)
                         self.emit 'error', err
                     else
+                        # Increment the current offset
+                        @offset = msg.update_id
+
                         for msg in result
                             self.handleUpdate msg
 

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -244,9 +244,7 @@ class Telegram extends Adapter
                     if (err)
                         self.emit 'error', err
                     else
-                        for msg in result
-                            # Increment the current offset
-                            self.offset = msg.update_id
+                        self.offset = result[result.length-1].update_id if result.length
 
                         for msg in result
                             self.handleUpdate msg


### PR DESCRIPTION
To reduce duplicate messages, update the offset immediately when Telegram responds.