### PR TITLE
Edited message

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -174,7 +174,7 @@ class Telegram extends Adapter
     
         @robot.logger.debug update
 
-        message = update.message
+        message = update.message || update.edited_message
         @robot.logger.info "Receiving message_id: " + message.message_id
 
         # Text event


### PR DESCRIPTION
There is a new `edited_message` inside the update payload that could block all the new messages.

https://core.telegram.org/bots/api#getting-updates

```
message = update.message || update.edited_message
@robot.logger.info "Receiving message_id: " + message.message_id

```

This resolve the issue in my case.