### PR TITLE
Fixes issue #52

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -69,20 +69,7 @@ class Telegram extends Adapter
     if autoMarkdown
       message.parse_mode = 'Markdown'
 
-    toString = (object) ->
-      result = {}
-
-      try
-        for key in Object.keys(object)
-          result[key] = toString(object[key])
-      catch e
-        result = "" + object;
-
-      return result
-
     if extra?
-      extra = toString(extra)
-
       for key, value of extra
         message[key] = value
 

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -86,15 +86,15 @@ describe('Telegram', function () {
       var extra = {extra: true, nested: {extra: true}, nullObject: null};
       message = telegram.applyExtraOptions(message, extra);
 
-      assert.equal("" + extra.extra, message.extra);
-      assert.equal("" + extra.nested.extra, message.nested.extra);
-      assert.equal("" + extra.nullObject, message.nullObject);
+      assert.equal(extra.extra, message.extra);
+      assert.equal(extra.nested.extra, message.nested.extra);
+      assert.equal(extra.nullObject, message.nullObject);
 
       // Mock the API object
       telegram.api = {
         invoke: function (method, opts, cb) {
-          assert.equal("" + extra.extra, opts.extra);
-          assert.equal("" + extra.nested.extra, opts.nested.extra);
+          assert.equal(extra.extra, opts.extra);
+          assert.equal(extra.nested.extra, opts.nested.extra);
           cb.apply(this, [null, {}]);
         }
       };


### PR DESCRIPTION
Fixes #52 . Removes the toString() method to parse extra params (`res.envelope.telegram`). The telegrambot lib already does this using `JSON.stringify()`.