### PR TITLE
Detect markdown emphasis within words only

### DIFF
--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -64,7 +64,7 @@ class Telegram extends Adapter
   ###
   applyExtraOptions: (message, extra) ->
     text = message.text
-    autoMarkdown = /\*.+\*/.test(text) or /_.+_/.test(text) or /\[.+\]\(.+\)/.test(text) or /`.+`/.test(text)
+    autoMarkdown = /\*.+\*/.test(text) or /\b_[^_]+_\b/.test(text) or /\[.+\]\(.+\)/.test(text) or /`.+`/.test(text)
 
     if autoMarkdown
       message.parse_mode = 'Markdown'


### PR DESCRIPTION
This fix urls with two underscores being misinterpreted as markdown emphasis lines. (eg. pug me links)

This do not allows mid-word markdown, but who would need it anyway?